### PR TITLE
fix: use 'released' trigger for build-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   contents: write


### PR DESCRIPTION
The 'published' event only fires when a release is first created.
The 'released' event fires when a pre-release is promoted to a full release by unchecking the pre-release checkbox.