### PR TITLE
fix(ci): make workflow safe for forks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
       - name: Checkout code
@@ -51,8 +54,6 @@ jobs:
       - name: Create Test Results Comment
         if: always() && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
-        permissions:
-          pull-requests: write
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
This PR modifies the PR workflow to support forks by cleanly handling permissions for comments. It ensures that PRs from public forks (which are read-only) do not fail due to permission errors.