### PR TITLE
🎨 Palette: Colorized status icons for vault list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-01 - Colorized CLI Status Icons
+**Learning:** For Go-based CLI tools, colorizing status icons (✓/✗) significantly improves scannability. To maintain a professional experience, it is critical to implement TTY detection and respect the `NO_COLOR` standard to avoid polluting logs or non-interactive pipes with ANSI escape codes.
+**Action:** Always implement a safe color utility that checks `os.Stdout.Stat()` and `os.Getenv("NO_COLOR")` before applying ANSI codes. Use empty-string success/failure helpers (e.g., `success("")`) to provide colorized status icons in tabular output without repeating the status text.

--- a/internal/cmd/color_test.go
+++ b/internal/cmd/color_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestColor(t *testing.T) {
+	// Test NO_COLOR
+	os.Setenv("NO_COLOR", "1")
+	if res := color("test", "32"); res != "test" {
+		t.Errorf("color() with NO_COLOR expected 'test', got %q", res)
+	}
+	os.Unsetenv("NO_COLOR")
+
+	// Test non-TTY (default in tests)
+	if res := color("test", "32"); res != "test" {
+		t.Errorf("color() in non-TTY expected 'test', got %q", res)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -151,3 +151,20 @@ func GetGPGBinary() string {
 func IsVerbose() bool {
 	return verbose
 }
+
+// color wraps text in ANSI color codes if stdout is a TTY and NO_COLOR is not set
+func color(s, c string) string {
+	if os.Getenv("NO_COLOR") != "" {
+		return s
+	}
+	if fi, err := os.Stdout.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+		return fmt.Sprintf("\033[%sm%s\033[0m", c, s)
+	}
+	return s
+}
+
+// success returns a green message with a checkmark
+func success(s string) string { return color("✓ "+s, "32") }
+
+// failure returns a red message with a cross
+func failure(s string) string { return color("✗ "+s, "31") }

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -154,9 +154,9 @@ func runVaultList(cmd *cobra.Command, args []string) error {
 		status := ""
 		if email != "" {
 			if hasAccess {
-				status = " ✓"
+				status = " " + success("")
 			} else {
-				status = " ✗"
+				status = " " + failure("")
 			}
 		}
 


### PR DESCRIPTION
🎨 Palette: Colorized status icons for vault list

💡 What: Added ANSI color support to the CLI and colorized the access status icons in the `vault list` command.
🎯 Why: Improves visual scannability of the vault list, allowing users to quickly see which vaults they have access to.
♿ Accessibility: High-contrast green (✓) and red (✗) icons provide clear visual feedback.
♿ Robustness: The implementation respects `NO_COLOR` and automatically disables colors when output is redirected to a file or pipe.

Changes:
- Added `color`, `success`, and `failure` helpers in `internal/cmd/root.go`.
- Applied color to status icons in `internal/cmd/vault.go`.
- Added unit tests in `internal/cmd/color_test.go`.
- Recorded learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [16214657769872229113](https://jules.google.com/task/16214657769872229113) started by @omar-nahhas*