### PR TITLE
🎨 Palette: Colorize success feedback in init command

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2026-02-02 - Micro-UX: Colorized Success Feedback
+
+**Learning:** Adding a splash of color to success indicators (like a green ✓) significantly improves the scannability of CLI output. Users can instantly confirm a successful operation without needing to read the full text. This is especially useful in multi-step initialization processes.
+
+**Action:** Use a dedicated `success()` utility for positive status icons to provide quick visual confirmation.

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -91,8 +91,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to export public key: %w", err)
 	}
 
-	fmt.Printf("✓ Initialized secrets store in %s\n", secretsDir)
-	fmt.Printf("✓ Exported your public key to %s\n", keyPath)
+	fmt.Printf("%s Initialized secrets store in %s\n", success("✓"), bold(secretsDir))
+	fmt.Printf("%s Exported your public key to %s\n", success("✓"), bold(keyPath))
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  1. Create a vault:  secrets-cli vault create <name>")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -172,6 +172,27 @@ func IsVerbose() bool {
 	return verbose
 }
 
+// color returns the string with ANSI color codes if stdout is a TTY and NO_COLOR is not set
+func color(s, c string) string {
+	if os.Getenv("NO_COLOR") != "" {
+		return s
+	}
+	if fi, err := os.Stdout.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+		return fmt.Sprintf("\033[%sm%s\033[0m", c, s)
+	}
+	return s
+}
+
+// success returns a green string (for ✓ and success messages)
+func success(s string) string {
+	return color(s, "32")
+}
+
+// bold returns a bold string
+func bold(s string) string {
+	return color(s, "1")
+}
+
 // validateName ensures a name is safe to use in file paths and command arguments
 func validateName(name string) error {
 	if name == "" {


### PR DESCRIPTION
Implemented a micro-UX improvement by adding colorized success feedback to the `init` command. This includes a green checkmark icon and bolded file paths to improve scannability and provide delightful visual confirmation of successful initialization. The implementation includes a TTY check and respects the `NO_COLOR` environment variable to ensure clean output in all environments.

---
*PR created automatically by Jules for task [13509669672269243359](https://jules.google.com/task/13509669672269243359) started by @omar-nahhas*