### PR TITLE
🎨 Palette: Add interactive prompts and empty state hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-11 - Prompt for stdin reading in CLI
+**Learning:** CLI tools that read from stdin without a prompt can appear to "hang" when run interactively, causing user confusion.
+**Action:** Always check if stdin is a terminal using `isTerminal` (via `os.ModeCharDevice`) and provide a descriptive prompt (e.g., "Enter value: ") when reading interactively, while remaining silent for piped/automated input.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -183,3 +183,12 @@ func validateName(name string) error {
 	}
 	return nil
 }
+
+// isTerminal returns true if the given file is a terminal
+func isTerminal(f *os.File) bool {
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -142,6 +142,7 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	if len(secrets) == 0 {
 		fmt.Printf("No secrets in vault: %s\n", vaultName)
+		fmt.Printf("Add your first secret with: secrets-cli set %s <name> <value>\n", vaultName)
 		return nil
 	}
 
@@ -225,6 +226,9 @@ func runSet(cmd *cobra.Command, args []string) error {
 		value = args[2]
 	} else {
 		// Read from stdin
+		if isTerminal(os.Stdin) {
+			fmt.Print("Enter secret value: ")
+		}
 		reader := bufio.NewReader(os.Stdin)
 		data, err := reader.ReadString('\n')
 		if err != nil && err.Error() != "EOF" {


### PR DESCRIPTION
Implemented two micro-UX improvements:
1. Added an interactive prompt when the `set` command reads from stdin, preventing the CLI from appearing to hang.
2. Added a helpful "next steps" hint when listing an empty vault.
Included a new `isTerminal` utility in `internal/cmd/root.go` to ensure prompts are only shown in interactive sessions.

---
*PR created automatically by Jules for task [10313968953334537846](https://jules.google.com/task/10313968953334537846) started by @East-rayyy*