### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-13 - Destructive CLI Actions and User Safety
+**Learning:** Destructive actions (like deleting vaults or secrets) should provide an interactive confirmation prompt when run in a terminal. This prevents accidental data loss while allowing automation via a `--force` flag. Checking for a terminal using `os.ModeCharDevice` ensures the tool doesn't hang in non-interactive environments.
+**Action:** Always implement a `confirm` helper that checks `isTerminal` before prompting, and provide a `--force` flag for all destructive operations.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,12 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !forceKey {
+		if !confirm(fmt.Sprintf("Are you sure you want to remove the public key for %s?", email)) {
+			return fmt.Errorf("use --force to confirm removal of key for: %s", email)
+		}
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,30 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// isTerminal checks if the given file is a terminal
+func isTerminal(f *os.File) bool {
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
+// confirm prompts the user for confirmation in interactive sessions
+func confirm(message string) bool {
+	if !isTerminal(os.Stdin) {
+		return false
+	}
+
+	fmt.Printf("%s [y/N] ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -275,7 +275,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+		if !confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName)) {
+			return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+		}
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -289,7 +289,9 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+		if !confirm(fmt.Sprintf("Are you sure you want to delete vault %q and all its secrets?", vaultName)) {
+			return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+		}
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
+WORKSPACE="${WORKSPACE:-/workspace}"
 SECRET_CLI="${WORKSPACE}/secrets-cli"
 
 # Source test utilities


### PR DESCRIPTION
I have implemented an interactive confirmation prompt for all destructive actions in the `secrets-cli`. Previously, these commands would simply fail with an error if the `--force` flag was not provided. Now, if the tool is run in an interactive terminal, it will ask the user for confirmation before proceeding. Non-interactive sessions (like CI/CD) still require the `--force` flag and will fail with an error if it's missing, ensuring no hangs occur.

Key changes:
- Created `isTerminal` and `confirm` utility functions in `internal/cmd/root.go`.
- Integrated these prompts into `vault delete`, `delete` (for secrets), and `key remove`.
- Added a `--force` flag to `key remove` for consistency across the CLI.
- Fixed a hardcoded path in `tests/e2e-tests.sh` to facilitate local testing.
- Documented the UX learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [6146542475433896294](https://jules.google.com/task/6146542475433896294) started by @East-rayyy*