### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force removal without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !forceKey && !confirm(fmt.Sprintf("Are you sure you want to remove the key for %q?", email)) {
+		return fmt.Errorf("use --force to confirm removal of key for %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,28 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// isTerminal checks if the file descriptor is a terminal
+func isTerminal(f *os.File) bool {
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
+// confirm prompts the user for confirmation in interactive terminals
+func confirm(message string) bool {
+	if !isTerminal(os.Stdin) {
+		return false
+	}
+	fmt.Printf("%s [y/N] ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -274,7 +274,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !forceSecret && !confirm(fmt.Sprintf("Are you sure you want to delete secret %s/%s?", vaultName, secretName)) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !forceDelete && !confirm(fmt.Sprintf("Are you sure you want to delete vault %q?", vaultName)) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
💡 **What**: Added interactive confirmation prompts for `vault delete`, `delete` (secret), and `key remove` commands.

🎯 **Why**: Prevents accidental data loss by providing a safety net in interactive terminals. This makes the CLI more "forgiving" and intuitive for human operators while maintaining full scriptability via the `--force` flag (which automated workflows should already be using).

♿ **Accessibility**: Improved usability by providing immediate, actionable feedback in interactive sessions.

🛠️ **Technical Changes**:
- Added `isTerminal(*os.File) bool` and `confirm(message string) bool` helpers to `internal/cmd/root.go`.
- Consistently applied the confirmation pattern across all destructive commands.
- Added a missing `--force` flag to `key remove` to align it with other deletion commands.
- Small improvement to `tests/e2e-tests.sh` to allow overriding `WORKSPACE` and `SECRET_CLI` environment variables.

⚠️ **Note**: Total lines of code change is ~43, staying within the 50-line boundary by focusing strictly on the UX enhancement.

---
*PR created automatically by Jules for task [16327106473030054633](https://jules.google.com/task/16327106473030054633) started by @East-rayyy*