### PR TITLE
🎨 Palette: Interactive confirmation prompts for destructive actions

### DIFF
--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force removal without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,15 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !forceKey {
+		if !isTerminal(os.Stdin) {
+			return fmt.Errorf("use --force to confirm removal of key for: %s", email)
+		}
+		if !confirm(fmt.Sprintf("Are you sure you want to remove the public key for %s?", email)) {
+			return fmt.Errorf("removal cancelled")
+		}
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,27 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// isTerminal checks if the given file is a terminal
+func isTerminal(f *os.File) bool {
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
+// confirm prompts the user for confirmation
+func confirm(message string) bool {
+	if !isTerminal(os.Stdin) {
+		return false
+	}
+	fmt.Printf("%s [y/N]: ", message)
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		response := strings.ToLower(strings.TrimSpace(scanner.Text()))
+		return response == "y" || response == "yes"
+	}
+	return false
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -275,7 +275,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+		if !isTerminal(os.Stdin) {
+			return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+		}
+		if !confirm(fmt.Sprintf("Are you sure you want to delete secret '%s/%s'?", vaultName, secretName)) {
+			return fmt.Errorf("deletion cancelled")
+		}
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -289,7 +289,12 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+		if !isTerminal(os.Stdin) {
+			return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+		}
+		if !confirm(fmt.Sprintf("Are you sure you want to delete vault '%s' and all its secrets?", vaultName)) {
+			return fmt.Errorf("deletion cancelled")
+		}
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -206,44 +206,44 @@ func (p *Pass) ReInit(gpgIDs []string) error {
 // It uses a count-based approach which is more robust across GPG versions than
 // trying to match exact key IDs (which can vary in format).
 func (p *Pass) VerifyEncryption(secretName string, expectedGPGIDs []string) error {
-secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
+	secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
-// First, verify all expected GPG IDs exist in the keyring
-for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", gpgID)
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
-}
-}
+	// First, verify all expected GPG IDs exist in the keyring
+	for _, gpgID := range expectedGPGIDs {
+		cmd := exec.Command("gpg", "--list-keys", gpgID)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
+		}
+	}
 
-// Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", secretPath)
-var stdout bytes.Buffer
-cmd.Stdout = &stdout
+	// Count recipients in the encrypted file
+	cmd := exec.Command("gpg", "--list-packets", secretPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("failed to list packets: %w", err)
-}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to list packets: %w", err)
+	}
 
-// Count how many encryption recipients are in the file
-// Each ":pubkey enc packet:" line represents one recipient
-keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
-matches := keyIDRegex.FindAllString(stdout.String(), -1)
-recipientCount := len(matches)
+	// Count how many encryption recipients are in the file
+	// Each ":pubkey enc packet:" line represents one recipient
+	keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
+	matches := keyIDRegex.FindAllString(stdout.String(), -1)
+	recipientCount := len(matches)
 
-if recipientCount == 0 {
-return fmt.Errorf("no encryption recipients found in %s", secretName)
-}
+	if recipientCount == 0 {
+		return fmt.Errorf("no encryption recipients found in %s", secretName)
+	}
 
-// Verify the count matches
-// Since we know pass was asked to encrypt to exactly these GPG IDs,
-// if the recipient count matches, encryption was successful
-if recipientCount != len(expectedGPGIDs) {
-return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
-secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
-}
+	// Verify the count matches
+	// Since we know pass was asked to encrypt to exactly these GPG IDs,
+	// if the recipient count matches, encryption was successful
+	if recipientCount != len(expectedGPGIDs) {
+		return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
+			secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
+	}
 
-return nil
+	return nil
 }
 
 func (p *Pass) GetGPGIDs() ([]string, error) {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
### 💡 What
Added interactive confirmation prompts for `vault delete`, `secrets delete`, and `key remove` commands. Added a missing `--force` flag to `key remove`. Fixed E2E test script to support local execution by allowing `WORKSPACE` and `SECRET_CLI` overrides.

### 🎯 Why
Prevents accidental data loss by ensuring users confirm irreversible actions in interactive terminals. Previously, users had to remember to add `--force` or would simply get an error message, which was an abrupt UX experience.

### ♿ Accessibility
Improved usability by providing immediate feedback and a safety net for destructive operations.

### 📸 Before/After
**Before:**
```bash
$ secrets-cli vault delete dev
Error: use --force to confirm deletion of vault: dev
```

**After:**
```bash
$ secrets-cli vault delete dev
Are you sure you want to delete vault 'dev' and all its secrets? [y/N]: y
✓ Deleted vault: dev
```


---
*PR created automatically by Jules for task [17690958682648945400](https://jules.google.com/task/17690958682648945400) started by @East-rayyy*