### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in secret commands

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -183,3 +183,16 @@ func validateName(name string) error {
 	}
 	return nil
 }
+
+// validateSecretName ensures a secret name is safe but allows slashes for organization
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name cannot be empty")
+	}
+	// Prevent path traversal and argument injection
+	if strings.Contains(name, "..") || strings.Contains(name, "//") || strings.Contains(name, "\\") ||
+		strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") || strings.HasPrefix(name, "-") {
+		return fmt.Errorf("invalid secret name: %s (contains illegal characters or path traversal)", name)
+	}
+	return nil
+}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -113,9 +113,10 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
-	vaultName := args[0]
+	secretsDir, email, vaultName := GetSecretsDir(), GetUserEmail(), args[0]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -161,10 +162,13 @@ func runList(cmd *cobra.Command, args []string) error {
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
-	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
-	vaultName := args[0]
-	secretName := args[1]
+	secretsDir, email, vaultName, secretName := GetSecretsDir(), GetUserEmail(), args[0], args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -199,10 +203,13 @@ func runGet(cmd *cobra.Command, args []string) error {
 }
 
 func runSet(cmd *cobra.Command, args []string) error {
-	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
-	vaultName := args[0]
-	secretName := args[1]
+	secretsDir, email, vaultName, secretName := GetSecretsDir(), GetUserEmail(), args[0], args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -254,10 +261,13 @@ func runSet(cmd *cobra.Command, args []string) error {
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
-	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
-	vaultName := args[0]
-	secretName := args[1]
+	secretsDir, email, vaultName, secretName := GetSecretsDir(), GetUserEmail(), args[0], args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -291,11 +301,16 @@ func runDelete(cmd *cobra.Command, args []string) error {
 }
 
 func runRename(cmd *cobra.Command, args []string) error {
-	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
-	vaultName := args[0]
-	oldName := args[1]
-	newName := args[2]
+	secretsDir, email, vaultName, oldName, newName := GetSecretsDir(), GetUserEmail(), args[0], args[1], args[2]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -329,11 +344,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 }
 
 func runCopy(cmd *cobra.Command, args []string) error {
-	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
-	srcVault := args[0]
-	secretName := args[1]
-	dstVault := args[2]
+	secretsDir, email, srcVault, secretName, dstVault := GetSecretsDir(), GetUserEmail(), args[0], args[1], args[2]
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -206,44 +206,44 @@ func (p *Pass) ReInit(gpgIDs []string) error {
 // It uses a count-based approach which is more robust across GPG versions than
 // trying to match exact key IDs (which can vary in format).
 func (p *Pass) VerifyEncryption(secretName string, expectedGPGIDs []string) error {
-secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
+	secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
-// First, verify all expected GPG IDs exist in the keyring
-for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", gpgID)
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
-}
-}
+	// First, verify all expected GPG IDs exist in the keyring
+	for _, gpgID := range expectedGPGIDs {
+		cmd := exec.Command("gpg", "--list-keys", gpgID)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
+		}
+	}
 
-// Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", secretPath)
-var stdout bytes.Buffer
-cmd.Stdout = &stdout
+	// Count recipients in the encrypted file
+	cmd := exec.Command("gpg", "--list-packets", secretPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("failed to list packets: %w", err)
-}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to list packets: %w", err)
+	}
 
-// Count how many encryption recipients are in the file
-// Each ":pubkey enc packet:" line represents one recipient
-keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
-matches := keyIDRegex.FindAllString(stdout.String(), -1)
-recipientCount := len(matches)
+	// Count how many encryption recipients are in the file
+	// Each ":pubkey enc packet:" line represents one recipient
+	keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
+	matches := keyIDRegex.FindAllString(stdout.String(), -1)
+	recipientCount := len(matches)
 
-if recipientCount == 0 {
-return fmt.Errorf("no encryption recipients found in %s", secretName)
-}
+	if recipientCount == 0 {
+		return fmt.Errorf("no encryption recipients found in %s", secretName)
+	}
 
-// Verify the count matches
-// Since we know pass was asked to encrypt to exactly these GPG IDs,
-// if the recipient count matches, encryption was successful
-if recipientCount != len(expectedGPGIDs) {
-return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
-secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
-}
+	// Verify the count matches
+	// Since we know pass was asked to encrypt to exactly these GPG IDs,
+	// if the recipient count matches, encryption was successful
+	if recipientCount != len(expectedGPGIDs) {
+		return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
+			secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
+	}
 
-return nil
+	return nil
 }
 
 func (p *Pass) GetGPGIDs() ([]string, error) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** User-provided secret names were not validated, allowing for path traversal (e.g., `../../`) and argument injection (e.g., `-flag`).
🎯 **Impact:** An attacker could use manipulated secret names to read or overwrite arbitrary GPG-encrypted files if they could influence the secret names used in the CLI.
🔧 **Fix:** 
- Implemented `validateSecretName` in `internal/cmd/root.go` to reject `..`, `//`, backslashes, leading/trailing slashes, and leading hyphens.
- Applied validation to all secret-related commands (`get`, `set`, `delete`, `rename`, `copy`, `list`) in `internal/cmd/secrets.go`.
- Ran `go fmt` to ensure standard formatting.
✅ **Verification:** 
- Attempted traversal with `./secrets-cli get dev "../../../etc/passwd"` which was correctly rejected.
- Verified that standard secret names like `database/password` still work correctly.
- Ensured no regression by running `make test`.

---
*PR created automatically by Jules for task [2413804724986107518](https://jules.google.com/task/2413804724986107518) started by @East-rayyy*