### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-16 - Interactive CLI Confirmation Pattern
+**Learning:** For destructive operations in CLI tools, requiring a `--force` flag is safe but can be frustrating for interactive users. A better UX pattern is to detect if the session is a terminal and provide an interactive confirmation prompt if the flag is missing.
+**Action:** Use `isTerminal(os.Stdout)` and a `confirm()` helper in future CLI projects to provide a smoother interactive experience while maintaining script safety.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,16 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !forceKey {
+		if isTerminal(os.Stdout) {
+			if !confirm(fmt.Sprintf("Are you sure you want to remove the key for '%s'?", email)) {
+				return fmt.Errorf("operation cancelled")
+			}
+		} else {
+			return fmt.Errorf("use --force to confirm removal of key: %s", email)
+		}
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,22 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// isTerminal checks if the given file is a terminal
+func isTerminal(f *os.File) bool {
+	stat, _ := f.Stat()
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
+// confirm prompts the user for confirmation
+func confirm(message string) bool {
+	fmt.Printf("%s [y/N]: ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -275,7 +275,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+		if isTerminal(os.Stdout) {
+			if !confirm(fmt.Sprintf("Are you sure you want to delete secret '%s' from vault '%s'?", secretName, vaultName)) {
+				return fmt.Errorf("operation cancelled")
+			}
+		} else {
+			return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+		}
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -289,7 +289,13 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+		if isTerminal(os.Stdout) {
+			if !confirm(fmt.Sprintf("Are you sure you want to delete vault '%s' and all its secrets?", vaultName)) {
+				return fmt.Errorf("operation cancelled")
+			}
+		} else {
+			return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+		}
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -206,44 +206,44 @@ func (p *Pass) ReInit(gpgIDs []string) error {
 // It uses a count-based approach which is more robust across GPG versions than
 // trying to match exact key IDs (which can vary in format).
 func (p *Pass) VerifyEncryption(secretName string, expectedGPGIDs []string) error {
-secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
+	secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
-// First, verify all expected GPG IDs exist in the keyring
-for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", gpgID)
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
-}
-}
+	// First, verify all expected GPG IDs exist in the keyring
+	for _, gpgID := range expectedGPGIDs {
+		cmd := exec.Command("gpg", "--list-keys", gpgID)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
+		}
+	}
 
-// Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", secretPath)
-var stdout bytes.Buffer
-cmd.Stdout = &stdout
+	// Count recipients in the encrypted file
+	cmd := exec.Command("gpg", "--list-packets", secretPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("failed to list packets: %w", err)
-}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to list packets: %w", err)
+	}
 
-// Count how many encryption recipients are in the file
-// Each ":pubkey enc packet:" line represents one recipient
-keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
-matches := keyIDRegex.FindAllString(stdout.String(), -1)
-recipientCount := len(matches)
+	// Count how many encryption recipients are in the file
+	// Each ":pubkey enc packet:" line represents one recipient
+	keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
+	matches := keyIDRegex.FindAllString(stdout.String(), -1)
+	recipientCount := len(matches)
 
-if recipientCount == 0 {
-return fmt.Errorf("no encryption recipients found in %s", secretName)
-}
+	if recipientCount == 0 {
+		return fmt.Errorf("no encryption recipients found in %s", secretName)
+	}
 
-// Verify the count matches
-// Since we know pass was asked to encrypt to exactly these GPG IDs,
-// if the recipient count matches, encryption was successful
-if recipientCount != len(expectedGPGIDs) {
-return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
-secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
-}
+	// Verify the count matches
+	// Since we know pass was asked to encrypt to exactly these GPG IDs,
+	// if the recipient count matches, encryption was successful
+	if recipientCount != len(expectedGPGIDs) {
+		return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
+			secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
+	}
 
-return nil
+	return nil
 }
 
 func (p *Pass) GetGPGIDs() ([]string, error) {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
💡 What: Added interactive confirmation prompts for `vault delete`, `secret delete`, and `key remove` commands.
🎯 Why: Prevents accidental data loss by providing a safety layer for interactive users, while still supporting automated workflows via the `--force` flag.
📸 Before/After:
Before: `secrets-cli delete dev secret` -> Error: "use --force to confirm deletion"
After: `secrets-cli delete dev secret` -> Prompt: "Are you sure you want to delete secret 'secret' from vault 'dev'? [y/N]:"
♿ Accessibility: Improved feedback and safety for keyboard/terminal users.

---
*PR created automatically by Jules for task [9386928449644803670](https://jules.google.com/task/9386928449644803670) started by @East-rayyy*