### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in secret names and emails

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Path traversal in `key add` and `vault create` commands allowed arbitrary file writes via manipulated email or vault names. Additionally, missing `--` separators in GPG/Pass wrappers allowed argument injection.
 **Learning:** CLI tools that construct file paths from user arguments are susceptible to traversal if not explicitly sanitized. Positional arguments starting with hyphens can also be misinterpreted as flags by underlying tools.
 **Prevention:** Use a centralized validation function to reject dangerous characters (`..`, `/`, `\`) and leading hyphens in names. Always use the `--` delimiter to separate options from positional arguments when calling external binaries.
+## 2026-02-16 - Path Traversal in Secret Names
+**Vulnerability:** While vault names were validated, secret names were not, allowing potential path traversal (e.g., `../../file`) even if underlying tools had some protection.
+**Learning:** Defense in depth requires validation at the application level, even if delegated tools (like `pass`) have their own protections. Secret names need a specific validator that allows slashes for organization but rejects traversal patterns.
+**Prevention:** Implement `validateSecretName` to allow single slashes but reject `..`, leading/trailing slashes, and double slashes. Apply this validation to all commands handling secret names.

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -47,6 +47,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check if already initialized
 	if _, err := os.Stat(secretsDir); !os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory already exists: %s. Remove it first or use a different path", secretsDir)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -183,3 +183,16 @@ func validateName(name string) error {
 	}
 	return nil
 }
+
+// validateSecretName ensures a secret name is safe but allows slashes for organization
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name cannot be empty")
+	}
+	// Reject path traversal, leading/trailing slashes, double slashes, and leading hyphens
+	if strings.Contains(name, "..") || strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") ||
+		strings.Contains(name, "//") || strings.Contains(name, "\\") || strings.HasPrefix(name, "-") {
+		return fmt.Errorf("invalid secret name: %s (contains illegal characters or path traversal)", name)
+	}
+	return nil
+}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -166,6 +166,10 @@ func runGet(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -203,6 +207,10 @@ func runSet(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	secretName := args[1]
+
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -259,6 +267,10 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -297,6 +309,13 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -334,6 +353,15 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -34,6 +34,10 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check if secrets directory exists
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in secret names and emails

Vulnerability:
Secret names were not validated, allowing potential path traversal (e.g., `../../file`) relative to the vault's password store. Additionally, emails used in `init` and `setup` commands were not validated, which could lead to file writes or reads outside the intended `.secrets/keys/` directory.

Impact:
An attacker with control over secret names or emails could potentially access or manipulate files outside the designated vault or secrets store directory.

Fix:
- Added `validateSecretName` in `internal/cmd/root.go` to safely allow slashes for organization while rejecting `..`, leading/trailing slashes, double slashes, backslashes, and leading hyphens.
- Applied `validateSecretName` to `get`, `set`, `delete`, `rename`, and `copy` commands in `internal/cmd/secrets.go`.
- Applied `validateName` to emails in `internal/cmd/init.go` and `internal/cmd/setup.go`.
- Improved `tests/e2e-tests.sh` to support local execution by allowing `WORKSPACE` and `SECRET_CLI` overrides.

Verification:
- Manually verified that traversal patterns and leading hyphens are rejected by the CLI.
- Ran Go unit tests (`make test`).
- Ran E2E tests locally (`tests/e2e-tests.sh`).
- Verified code changes are around 50 lines.

---
*PR created automatically by Jules for task [6286591996807981241](https://jules.google.com/task/6286591996807981241) started by @East-rayyy*