### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-17 - Interactive Confirmation for Destructive Actions
+**Learning:** Hard-failing a command when a required confirmation flag is missing (like `--force`) creates friction for interactive users. Providing a prompt instead allows the user to stay in their flow while still maintaining safety for scripts.
+**Action:** Use a `Confirm` helper that checks if stdin is a terminal before prompting, ensuring non-interactive environments still require the explicit flag.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,21 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm asks the user for confirmation.
+// It returns true if the user enters 'y' or 'yes', false otherwise.
+// If stdin is not a terminal, it returns false without prompting.
+func Confirm(message string) bool {
+	// Check if stdin is a terminal
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N] ", message)
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	input = strings.ToLower(strings.TrimSpace(input))
+	return input == "y" || input == "yes"
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -274,8 +274,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+	if !forceSecret && !Confirm(fmt.Sprintf("Are you sure you want to delete secret '%s/%s'?", vaultName, secretName)) {
+		return fmt.Errorf("deletion cancelled. Use --force to skip confirmation")
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,8 +288,8 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+	if !forceDelete && !Confirm(fmt.Sprintf("Are you sure you want to permanently delete vault '%s' and ALL its secrets?", vaultName)) {
+		return fmt.Errorf("deletion cancelled. Use --force to skip confirmation")
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
This PR adds a micro-UX improvement to the secrets-cli by introducing interactive confirmation prompts for destructive actions. 

Previously, running `secrets-cli vault delete <vault>` or `secrets-cli delete <vault> <secret>` without the `--force` flag would result in a hard error. Now, if the user is in an interactive terminal, they are prompted for confirmation. If they confirm with 'y' or 'yes', the action proceeds. In non-interactive environments (pipes, CI), the original behavior is preserved to ensure safety.

Changes:
- Implemented `Confirm` helper in `internal/cmd/root.go`.
- Updated `vault delete` logic in `internal/cmd/vault.go`.
- Updated secret `delete` logic in `internal/cmd/secrets.go`.
- Fixed `tests/e2e-tests.sh` to support `WORKSPACE` environment variable override for local testing.


---
*PR created automatically by Jules for task [12621185426779284445](https://jules.google.com/task/12621185426779284445) started by @East-rayyy*