### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Validation and Argument Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** Path traversal in `key add` and `vault create` commands allowed arbitrary file writes via manipulated email or vault names. Additionally, missing `--` separators in GPG/Pass wrappers allowed argument injection.
 **Learning:** CLI tools that construct file paths from user arguments are susceptible to traversal if not explicitly sanitized. Positional arguments starting with hyphens can also be misinterpreted as flags by underlying tools.
 **Prevention:** Use a centralized validation function to reject dangerous characters (`..`, `/`, `\`) and leading hyphens in names. Always use the `--` delimiter to separate options from positional arguments when calling external binaries.
+
+## 2026-02-05 - Inconsistent Input Validation Across Command Handlers
+**Vulnerability:** While security validation functions like `validateName` were present, they were not applied consistently across all CLI command handlers, leaving some paths vulnerable to path traversal and argument injection.
+**Learning:** Security controls must be applied at every trust boundary. Centralizing validation logic is good, but it's only effective if every entry point that receives user-controlled input invokes it.
+**Prevention:** Audit all command handlers to ensure they validate every positional argument and flag that is used in sensitive operations (filesystem access, shell execution). Use `validateName` for simple identifiers and `validateSecretName` for hierarchical paths.

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -56,6 +56,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 	if email == "" {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
+	if err := validateName(email); err != nil {
+		return err
+	}
 
 	// Check GPG key exists
 	g := gpg.New(GetGPGBinary())

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -159,6 +159,9 @@ func runKeyAdd(cmd *cobra.Command, args []string) error {
 func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
+	if err := validateName(email); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -183,3 +183,17 @@ func validateName(name string) error {
 	}
 	return nil
 }
+
+// validateSecretName ensures a secret name is safe to use in file paths and command arguments
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name cannot be empty")
+	}
+	// Allow slashes in the middle but reject them at start/end or doubled
+	// Prevent path traversal and argument injection
+	if strings.Contains(name, "..") || strings.Contains(name, "\\") || strings.Contains(name, "//") ||
+		strings.HasPrefix(name, "-") || strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") {
+		return fmt.Errorf("invalid secret name: %s (contains illegal characters or path traversal)", name)
+	}
+	return nil
+}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -116,6 +116,9 @@ func runList(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -165,6 +168,12 @@ func runGet(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	secretName := args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -203,6 +212,12 @@ func runSet(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	secretName := args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -258,6 +273,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	secretName := args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -296,6 +317,15 @@ func runRename(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	oldName := args[1]
 	newName := args[2]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -334,6 +364,20 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -43,6 +43,9 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	if email == "" {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
+	if err := validateName(email); err != nil {
+		return err
+	}
 
 	// Load config
 	cfg, err := config.LoadConfig(secretsDir)

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -187,6 +187,9 @@ func runVaultCreate(cmd *cobra.Command, args []string) error {
 	if email == "" {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
+	if err := validateName(email); err != nil {
+		return err
+	}
 
 	// Check vault doesn't exist
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
@@ -245,6 +248,9 @@ func runVaultCreate(cmd *cobra.Command, args []string) error {
 func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -282,6 +288,9 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -305,6 +314,12 @@ func runVaultAddMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -377,6 +392,12 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {

--- a/internal/gpg/gpg.go
+++ b/internal/gpg/gpg.go
@@ -80,7 +80,7 @@ func (g *GPG) ExportPublicKeyToFile(email, filePath string) error {
 
 // ImportKey imports a key from a file
 func (g *GPG) ImportKey(keyPath string) error {
-	_, err := g.run("--import", keyPath)
+	_, err := g.run("--import", "--", keyPath)
 	return err
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing input validation for vault names, emails, and secret names across multiple command handlers, and missing `--` separators in GPG/Pass wrappers.
🎯 Impact: Potential path traversal (arbitrary file access/write) and argument injection (executing unintended flags/commands) via malicious inputs starting with hyphens or containing traversal sequences.
🔧 Fix: Implemented `validateSecretName`, applied consistent validation across all command handlers, and added `--` separators to external command calls.
✅ Verification: Ran `make test` and verified that invalid inputs are correctly rejected by the CLI.

---
*PR created automatically by Jules for task [16673386282923413596](https://jules.google.com/task/16673386282923413596) started by @East-rayyy*