### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-20 - Interactive confirmation for destructive CLI actions
+**Learning:** Destructive actions in CLIs should not just fail when a force flag is missing, but should offer an interactive prompt in TTY environments to improve user flow while maintaining safety.
+**Action:** Use a `Confirm` helper that checks for TTY (os.Stdin.Stat().Mode() & os.ModeCharDevice) to provide interactivity without breaking CI/CD pipelines.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -171,6 +171,9 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no key found for %s", email)
 	}
 
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the public key for %s?", email), false) {
+		return fmt.Errorf("removal cancelled")
+	}
 	if err := os.Remove(keyPath); err != nil {
 		return fmt.Errorf("failed to remove key: %w", err)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,20 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation [y/N]
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil || (fileInfo.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+	fmt.Printf("\033[33m%s\033[0m [y/N]: ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, _ := reader.ReadString('\n')
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -274,8 +274,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %s/%s?", vaultName, secretName), forceSecret) {
+		return fmt.Errorf("deletion cancelled")
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,8 +288,8 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %s and all its secrets?", vaultName), forceDelete) {
+		return fmt.Errorf("deletion cancelled")
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
💡 What: Added interactive confirmation prompts for `vault delete`, secret `delete`, and `key remove` commands.
🎯 Why: Prevents accidental data loss while improving the user flow by allowing confirmation without re-running the command with a `--force` flag.
📸 Before/After:
- Before: `vault delete test` -> `error: use --force to confirm deletion`
- After: `vault delete test` -> `Are you sure you want to delete vault test and all its secrets? [y/N]: `
♿ Accessibility: Improves usability by providing clear feedback and preventing terminal-based "dead ends".

Also includes a developer-experience fix for the E2E test script to allow local execution.

---
*PR created automatically by Jules for task [9547037824174723948](https://jules.google.com/task/9547037824174723948) started by @East-rayyy*