### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix input validation and argument injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,7 @@
+## 2026-02-05 - Comprehensive Input Validation for Secrets
+**Vulnerability:** Many CLI commands lacked input validation for secret names, vault names, and emails, creating risks of path traversal and argument injection.
+**Learning:** Even if core functions have some validation, it must be applied consistently at all entry points (CLI command handlers) to ensure no unvalidated data reaches sensitive operations.
+**Prevention:** Use specialized validation functions like `validateSecretName` (allowing slashes) and `validateName` (rejecting slashes) consistently across all command handlers.
 ## 2026-02-01 - Argument Injection in CLI Wrappers
 **Vulnerability:** User-controlled positional arguments (like emails or secret names) starting with hyphens could be interpreted as flags by underlying CLI tools (`gpg`, `pass`), leading to argument injection.
 **Learning:** Wrapping external CLI tools requires careful handling of positional arguments. Even if `exec.Command` prevents shell injection, it doesn't prevent the target binary from misinterpreting arguments as flags.

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -35,6 +35,13 @@ func init() {
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
+	email := GetUserEmail()
+	if email != "" {
+		if err := validateName(email); err != nil {
+			return err
+		}
+	}
+
 	// Require git repository for proper secrets preservation
 	gitRoot, err := RequireGitRepository()
 	if err != nil {
@@ -45,7 +52,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	secretsDir := GetSecretsDir()
-	email := GetUserEmail()
 
 	// Check if already initialized
 	if _, err := os.Stat(secretsDir); !os.IsNotExist(err) {

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -183,3 +183,17 @@ func validateName(name string) error {
 	}
 	return nil
 }
+
+// validateSecretName ensures a secret name is safe to use in file paths and command arguments
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name cannot be empty")
+	}
+	// Prevent path traversal and argument injection
+	// Allow '/' but not '..', '\', '//', leading/trailing '/', or leading '-'
+	if strings.Contains(name, "..") || strings.Contains(name, "\\") || strings.Contains(name, "//") ||
+		strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") || strings.HasPrefix(name, "-") {
+		return fmt.Errorf("invalid secret name: %s (contains illegal characters or path traversal)", name)
+	}
+	return nil
+}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -166,6 +170,13 @@ func runGet(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -203,6 +214,13 @@ func runSet(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	secretName := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
@@ -259,6 +277,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -297,6 +322,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -334,6 +369,21 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -34,6 +34,12 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if email != "" {
+		if err := validateName(email); err != nil {
+			return err
+		}
+	}
+
 	// Check if secrets directory exists
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/validation_test.go
+++ b/internal/cmd/validation_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"dev", false},
+		{"production", false},
+		{"alice@example.com", false},
+		{"", true},
+		{"../secrets", true},
+		{"/etc/passwd", true},
+		{"\\windowspath", true},
+		{"-arg", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateName(tt.name); (err != nil) != tt.wantErr {
+				t.Errorf("validateName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSecretName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"password", false},
+		{"db/password", false},
+		{"cloud/api/key", false},
+		{"", true},
+		{"../secret", true},
+		{"db/../secret", true},
+		{"db\\password", true},
+		{"db//password", true},
+		{"/db/password", true},
+		{"db/password/", true},
+		{"-secret", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateSecretName(tt.name); (err != nil) != tt.wantErr {
+				t.Errorf("validateSecretName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -283,6 +287,10 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -305,6 +313,13 @@ func runVaultAddMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -377,6 +392,13 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {

--- a/internal/gpg/gpg.go
+++ b/internal/gpg/gpg.go
@@ -80,7 +80,7 @@ func (g *GPG) ExportPublicKeyToFile(email, filePath string) error {
 
 // ImportKey imports a key from a file
 func (g *GPG) ImportKey(keyPath string) error {
-	_, err := g.run("--import", keyPath)
+	_, err := g.run("--import", "--", keyPath)
 	return err
 }
 

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -210,14 +210,14 @@ secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
 // First, verify all expected GPG IDs exist in the keyring
 for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", gpgID)
+cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
 if err := cmd.Run(); err != nil {
 return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
 }
 }
 
 // Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", secretPath)
+cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
 var stdout bytes.Buffer
 cmd.Stdout = &stdout
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix input validation and argument injection

This PR introduces comprehensive input validation for all user-provided arguments (vault names, secret names, and emails) across all CLI commands to prevent path traversal and argument injection.

### Changes:
- Implemented `validateSecretName` in `internal/cmd/root.go` to safely allow slashes in secret paths while rejecting `..`, `\\`, `//`, and leading hyphens.
- Applied `validateName` and `validateSecretName` to all command handlers in `internal/cmd/vault.go`, `internal/cmd/key.go`, `internal/cmd/secrets.go`, `internal/cmd/setup.go`, and `internal/cmd/init.go`.
- Hardened GPG and Pass wrappers in `internal/pass/pass.go` and `internal/gpg/gpg.go` by adding the `--` separator to `exec.Command` calls.
- Added comprehensive unit tests in `internal/cmd/validation_test.go`.
- Fixed a "no new variables on left side of :=" build error in `internal/cmd/init.go`.

### Security Context:
- **Severity**: MEDIUM
- **Vulnerability**: Incomplete input validation and missing command delimiters.
- **Impact**: Mitigates risks of path traversal (accessing files outside the vault) and argument injection (manipulating underlying `gpg` or `pass` behavior via malicious inputs starting with `-`).
- **Verification**: All tests passed via `make test`.

---
*PR created automatically by Jules for task [6450836566937758089](https://jules.google.com/task/6450836566937758089) started by @East-rayyy*