### PR TITLE
🎨 Palette: Add interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-22 - Reusable Interactive Confirmation Pattern
+**Learning:** Destructive CLI actions should always be guarded by a confirmation prompt to prevent accidental data loss, but must respect a `--force` flag for scripting and non-interactive environments (CI). Checking for a TTY ensures the CLI doesn't hang when no terminal is present.
+**Action:** Use the `Confirm(message string, force bool) bool` helper in `internal/cmd/root.go` for any new destructive commands.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile        string
+	forceKeyRemove bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKeyRemove, "force", "f", false, "Force removal without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the public key for %s?", email), forceKeyRemove) {
+		return fmt.Errorf("removal cancelled. Use --force to bypass confirmation")
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -182,4 +183,30 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation.
+// It returns true if force is true, false in non-interactive environments (CI) unless forced,
+// and prompts the user [y/N] in a terminal.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if stdin is a terminal
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil || (fileInfo.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N]: ", message)
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -274,8 +274,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret '%s/%s'?", vaultName, secretName), forceSecret) {
+		return fmt.Errorf("deletion cancelled. Use --force to bypass confirmation")
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,8 +288,8 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault '%s' and all its secrets?", vaultName), forceDelete) {
+		return fmt.Errorf("deletion cancelled. Use --force to bypass confirmation")
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {


### PR DESCRIPTION
💡 **What**: Added an interactive confirmation prompt for destructive actions (deleting vaults, secrets, and public keys). Introduced a reusable `Confirm` helper function in the `cmd` package.

🎯 **Why**: Previously, the CLI either failed immediately when a `--force` flag was missing or performed destructive actions without confirmation. This improvement makes the tool safer for interactive use while maintaining scriptability via the `--force` flag.

📸 **Before/After**:
* **Before**: `secrets-cli vault delete dev` would simply error out: `use --force to confirm deletion...`.
* **After**: `secrets-cli vault delete dev` now prompts: `Are you sure you want to delete vault 'dev' and all its secrets? [y/N]: `.

♿ **Accessibility**: Enhanced safety and guidance for interactive users, reducing the risk of accidental data loss. Non-interactive environments (CI) are automatically handled by failing safely unless `--force` is provided.

---
*PR created automatically by Jules for task [10141118066495345582](https://jules.google.com/task/10141118066495345582) started by @East-rayyy*