### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection and path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** Path traversal in `key add` and `vault create` commands allowed arbitrary file writes via manipulated email or vault names. Additionally, missing `--` separators in GPG/Pass wrappers allowed argument injection.
 **Learning:** CLI tools that construct file paths from user arguments are susceptible to traversal if not explicitly sanitized. Positional arguments starting with hyphens can also be misinterpreted as flags by underlying tools.
 **Prevention:** Use a centralized validation function to reject dangerous characters (`..`, `/`, `\`) and leading hyphens in names. Always use the `--` delimiter to separate options from positional arguments when calling external binaries.
+
+## 2026-02-22 - Argument Injection and Path Traversal in Secret Commands
+**Vulnerability:** Command handlers for secret operations (`get`, `set`) and vault member management (`add-member`) were missing input validation, potentially allowing path traversal. Additionally, some internal GPG/Pass calls lacked the `--` separator, risking argument injection.
+**Learning:** Even with existing validation functions like `validateName`, it is easy to miss applying them to new command handlers or specific arguments like secret paths that require different rules (e.g., allowing slashes).
+**Prevention:** Apply `validateName` or `validateSecretName` to all user-controlled positional arguments. Ensure all CLI wrappers use the `--` separator before positional arguments to prevent them from being interpreted as flags.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -173,6 +173,7 @@ func IsVerbose() bool {
 }
 
 // validateName ensures a name is safe to use in file paths and command arguments
+// (e.g. vault names, emails)
 func validateName(name string) error {
 	if name == "" {
 		return fmt.Errorf("name cannot be empty")
@@ -180,6 +181,24 @@ func validateName(name string) error {
 	// Prevent path traversal and argument injection
 	if strings.Contains(name, "..") || strings.ContainsAny(name, "/\\") || strings.HasPrefix(name, "-") {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
+	}
+	return nil
+}
+
+// validateSecretName ensures a secret name is safe to use.
+// It allows slashes for organization but prevents traversal and argument injection.
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name cannot be empty")
+	}
+	// Prevent path traversal, backslashes, double slashes, and leading/trailing slashes
+	if strings.Contains(name, "..") ||
+		strings.Contains(name, "\\") ||
+		strings.Contains(name, "//") ||
+		strings.HasPrefix(name, "/") ||
+		strings.HasSuffix(name, "/") ||
+		strings.HasPrefix(name, "-") {
+		return fmt.Errorf("invalid secret name: %s (must not contain '..', '\\', '//', or start/end with '/')", name)
 	}
 	return nil
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -166,6 +166,13 @@ func runGet(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -203,6 +210,13 @@ func runSet(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	secretName := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/validation_test.go
+++ b/internal/cmd/validation_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid name", "dev", false},
+		{"valid email", "alice@example.com", false},
+		{"empty name", "", true},
+		{"path traversal", "../test", true},
+		{"slash in name", "dev/prod", true},
+		{"backslash in name", "dev\\prod", true},
+		{"leading hyphen", "-flag", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateName(tt.input); (err != nil) != tt.wantErr {
+				t.Errorf("validateName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSecretName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid secret", "database/password", false},
+		{"valid simple secret", "apikey", false},
+		{"empty name", "", true},
+		{"path traversal", "../test", true},
+		{"backslash", "test\\secret", true},
+		{"double slash", "test//secret", true},
+		{"leading slash", "/test", true},
+		{"trailing slash", "test/", true},
+		{"leading hyphen", "-flag", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateSecretName(tt.input); (err != nil) != tt.wantErr {
+				t.Errorf("validateSecretName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -306,6 +306,13 @@ func runVaultAddMember(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	memberEmail := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)

--- a/internal/gpg/gpg.go
+++ b/internal/gpg/gpg.go
@@ -80,7 +80,7 @@ func (g *GPG) ExportPublicKeyToFile(email, filePath string) error {
 
 // ImportKey imports a key from a file
 func (g *GPG) ImportKey(keyPath string) error {
-	_, err := g.run("--import", keyPath)
+	_, err := g.run("--import", "--", keyPath)
 	return err
 }
 

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -210,14 +210,14 @@ secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
 // First, verify all expected GPG IDs exist in the keyring
 for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", gpgID)
+cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
 if err := cmd.Run(); err != nil {
 return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
 }
 }
 
 // Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", secretPath)
+cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
 var stdout bytes.Buffer
 cmd.Stdout = &stdout
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix argument injection and path traversal

Summary:
This PR improves the security of the secrets-cli by addressing potential argument injection in GPG/Pass wrappers and adding input validation to critical command handlers.

🚨 Severity: HIGH
💡 Vulnerability: User-controlled positional arguments could be interpreted as flags by GPG/Pass or used for path traversal.
🎯 Impact: Potential arbitrary file read/write or command option manipulation.
🔧 Fix:
- Added '--' separator to GPG and Pass CLI wrappers.
- Implemented 'validateSecretName' for secure secret path handling.
- Applied 'validateName' and 'validateSecretName' to 'get', 'set', and 'add-member' commands.
✅ Verification:
- Unit tests added in 'internal/cmd/validation_test.go'.
- Existing tests pass with 'go test ./...'.

---
*PR created automatically by Jules for task [8433960269577663028](https://jules.google.com/task/8433960269577663028) started by @East-rayyy*