### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in multiple CLI commands

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** Command handlers for secret operations (`get`, `set`) and vault member management (`add-member`) were missing input validation, potentially allowing path traversal. Additionally, some internal GPG/Pass calls lacked the `--` separator, risking argument injection.
 **Learning:** Even with existing validation functions like `validateName`, it is easy to miss applying them to new command handlers or specific arguments like secret paths that require different rules (e.g., allowing slashes).
 **Prevention:** Apply `validateName` or `validateSecretName` to all user-controlled positional arguments. Ensure all CLI wrappers use the `--` separator before positional arguments to prevent them from being interpreted as flags.
+
+## 2026-02-24 - Comprehensive Input Validation Across All CLI Commands
+**Vulnerability:** Multiple command handlers (`list`, `delete`, `rename`, `copy`, `vault info`, `vault delete`, `vault remove-member`, `key remove`, `export`, `sync`, `init`, `setup`) were missing input validation for vault names, secret names, or member emails, risking path traversal.
+**Learning:** Security validation must be applied comprehensively to all entry points, not just the most obvious ones (like `get`/`set`). Even helper commands like `init` or `setup` can be vulnerable if they use user-provided data to construct paths.
+**Prevention:** Perform a comprehensive audit of all command handlers to ensure `validateName` or `validateSecretName` is applied to every user-controlled argument used in file system operations.

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +127,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -57,6 +57,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check GPG key exists
 	g := gpg.New(GetGPGBinary())
 	if !g.KeyExists(email) {

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -273,6 +277,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +322,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +369,21 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -44,6 +44,10 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Load config
 	cfg, err := config.LoadConfig(secretsDir)
 	if err != nil {

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -282,6 +286,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -384,6 +392,13 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -206,44 +206,44 @@ func (p *Pass) ReInit(gpgIDs []string) error {
 // It uses a count-based approach which is more robust across GPG versions than
 // trying to match exact key IDs (which can vary in format).
 func (p *Pass) VerifyEncryption(secretName string, expectedGPGIDs []string) error {
-secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
+	secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
-// First, verify all expected GPG IDs exist in the keyring
-for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
-}
-}
+	// First, verify all expected GPG IDs exist in the keyring
+	for _, gpgID := range expectedGPGIDs {
+		cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
+		}
+	}
 
-// Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
-var stdout bytes.Buffer
-cmd.Stdout = &stdout
+	// Count recipients in the encrypted file
+	cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("failed to list packets: %w", err)
-}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to list packets: %w", err)
+	}
 
-// Count how many encryption recipients are in the file
-// Each ":pubkey enc packet:" line represents one recipient
-keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
-matches := keyIDRegex.FindAllString(stdout.String(), -1)
-recipientCount := len(matches)
+	// Count how many encryption recipients are in the file
+	// Each ":pubkey enc packet:" line represents one recipient
+	keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
+	matches := keyIDRegex.FindAllString(stdout.String(), -1)
+	recipientCount := len(matches)
 
-if recipientCount == 0 {
-return fmt.Errorf("no encryption recipients found in %s", secretName)
-}
+	if recipientCount == 0 {
+		return fmt.Errorf("no encryption recipients found in %s", secretName)
+	}
 
-// Verify the count matches
-// Since we know pass was asked to encrypt to exactly these GPG IDs,
-// if the recipient count matches, encryption was successful
-if recipientCount != len(expectedGPGIDs) {
-return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
-secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
-}
+	// Verify the count matches
+	// Since we know pass was asked to encrypt to exactly these GPG IDs,
+	// if the recipient count matches, encryption was successful
+	if recipientCount != len(expectedGPGIDs) {
+		return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
+			secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
+	}
 
-return nil
+	return nil
 }
 
 func (p *Pass) GetGPGIDs() ([]string, error) {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing input validation for vault names, secret names, and emails in several command handlers.
🎯 Impact: Attackers could potentially perform path traversal to read or write files outside the intended directories (e.g., accessing /etc/passwd or overwriting system files) if they can control these arguments.
🔧 Fix: Applied validateName and validateSecretName to all missing command handlers in internal/cmd/.
✅ Verification: Verified via unit tests (TestValidateName, TestValidateSecretName) and E2E tests (including a custom security test suite for traversal patterns).

---
*PR created automatically by Jules for task [9613135170947842965](https://jules.google.com/task/9613135170947842965) started by @East-rayyy*