### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal vulnerabilities

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,11 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	// Validate vault name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +128,11 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	// Validate vault name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -57,6 +57,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
 
+	// Validate email to prevent path traversal and argument injection
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check GPG key exists
 	g := gpg.New(GetGPGBinary())
 	if !g.KeyExists(email) {

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -115,6 +115,7 @@ func runKeyAdd(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	// Validate email to prevent path traversal and argument injection
 	if err := validateName(email); err != nil {
 		return err
 	}
@@ -159,6 +160,11 @@ func runKeyAdd(cmd *cobra.Command, args []string) error {
 func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
+
+	// Validate email to prevent path traversal and argument injection
+	if err := validateName(email); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,11 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	// Validate vault name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -166,6 +171,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	// Validate names to prevent path traversal and argument injection
 	if err := validateName(vaultName); err != nil {
 		return err
 	}
@@ -273,6 +279,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +324,17 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +372,22 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -44,6 +44,11 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
 
+	// Validate email to prevent path traversal and argument injection
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Load config
 	cfg, err := config.LoadConfig(secretsDir)
 	if err != nil {

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,11 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	// Validate vault name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -283,6 +288,11 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	// Validate vault name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -306,6 +316,7 @@ func runVaultAddMember(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	memberEmail := args[1]
 
+	// Validate names to prevent path traversal and argument injection
 	if err := validateName(vaultName); err != nil {
 		return err
 	}
@@ -384,6 +395,14 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Multiple CLI commands were using user-provided arguments directly in file path construction without validation.
🎯 Impact: An attacker could potentially read, write, or delete arbitrary files on the system by providing manipulated vault names, secret names, or emails (e.g., `../etc/passwd`).
🔧 Fix: Applied `validateName` and `validateSecretName` to all user-controlled positional arguments and relevant flags across all command handlers.
✅ Verification: Verified using `tests/repro_traversal.sh` which attempts path traversal on multiple commands. All attempts are now correctly blocked. Existing unit tests also pass.

---
*PR created automatically by Jules for task [12732230998688378199](https://jules.google.com/task/12732230998688378199) started by @East-rayyy*