### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal and argument injection in CLI commands

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** Command handlers for secret operations (`get`, `set`) and vault member management (`add-member`) were missing input validation, potentially allowing path traversal. Additionally, some internal GPG/Pass calls lacked the `--` separator, risking argument injection.
 **Learning:** Even with existing validation functions like `validateName`, it is easy to miss applying them to new command handlers or specific arguments like secret paths that require different rules (e.g., allowing slashes).
 **Prevention:** Apply `validateName` or `validateSecretName` to all user-controlled positional arguments. Ensure all CLI wrappers use the `--` separator before positional arguments to prevent them from being interpreted as flags.
+
+## 2026-02-26 - Incomplete Application of Input Validation
+**Vulnerability:** Path traversal and argument injection risks remained in several CLI commands (`list`, `delete`, `rename`, `copy`, `vault info`, `vault delete`, `vault remove-member`, `key remove`, `setup`, `init`) because input validation was inconsistently applied across the codebase.
+**Learning:** Security fixes are often applied partially. A vulnerability fixed in one command (e.g., `get` or `set`) might still exist in others (`delete`, `rename`) that use the same underlying vulnerable patterns.
+**Prevention:** When identifying a vulnerability in a CLI command, perform a comprehensive audit of all other command handlers to ensure consistent application of security patterns (like `validateName`) to all user-provided inputs.

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +127,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -57,6 +57,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check GPG key exists
 	g := gpg.New(GetGPGBinary())
 	if !g.KeyExists(email) {

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -273,6 +277,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +322,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +369,21 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -44,6 +44,10 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email is required. Use --email flag or set USER_EMAIL environment variable")
 	}
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Load config
 	cfg, err := config.LoadConfig(secretsDir)
 	if err != nil {

--- a/internal/cmd/validation_test.go
+++ b/internal/cmd/validation_test.go
@@ -12,6 +12,8 @@ func TestValidateName(t *testing.T) {
 	}{
 		{"valid name", "dev", false},
 		{"valid email", "alice@example.com", false},
+		{"valid email with subdomains", "bob@mail.dev.example.com", false},
+		{"valid email with plus", "user+label@example.com", false},
 		{"empty name", "", true},
 		{"path traversal", "../test", true},
 		{"slash in name", "dev/prod", true},

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -282,6 +286,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -384,6 +392,13 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing input validation for vault names, secret names, and emails in multiple CLI commands.
🎯 Impact: Attackers could potentially delete or overwrite arbitrary files on the user's system by providing manipulated names containing path traversal characters (.., /, \).
🔧 Fix: Consistently applied validateName and validateSecretName to all user-provided positional arguments in CLI command handlers.
✅ Verification: Verified with unit tests and manual repro scripts that path traversal attempts are now blocked with an "invalid name" error. Added unit tests for complex email formats to ensure no regressions for valid users.

---
*PR created automatically by Jules for task [7329926000159057491](https://jules.google.com/task/7329926000159057491) started by @East-rayyy*