### PR TITLE
🎨 Palette: Add interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-02-26 - Interactive Confirmation for Destructive Actions
+**Learning:** For CLI tools, UX is improved by providing interactive confirmation prompts for destructive operations in a TTY, while maintaining strict "fail-fast" behavior in non-interactive environments (CI) unless explicitly overridden by a force flag. Using quoted string formatting (`%q`) for identifiers in prompts helps distinguish them from the surrounding message.
+**Action:** Always implement a `Confirm` helper that detects TTY status and use it in all delete/remove command handlers with `%q` for entity names.
+
+## 2026-02-26 - Flexible E2E Test Environments
+**Learning:** Hardcoded paths in E2E scripts hinder local testing on developer machines. Providing environment variable overrides with sensible defaults (e.g., `WORKSPACE="${WORKSPACE:-/workspace}"`) allows for greater flexibility and easier debugging without breaking the primary containerized test environment.
+**Action:** Use the `${VAR:-default}` shell parameter expansion for critical paths in test scripts to support environment overrides.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile        string
+	forceKeyRemove bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKeyRemove, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove public key for %q?", email), forceKeyRemove) {
+		return fmt.Errorf("use --force to confirm removal of key for: %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,31 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation with [y/N].
+// If force is true, it returns true without prompting.
+// If not a terminal, it returns false to ensure non-interactive environments fail without --force.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if we're in a terminal
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil || (fileInfo.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N]: ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,7 +288,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %q?", vaultName), forceDelete) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -206,44 +206,44 @@ func (p *Pass) ReInit(gpgIDs []string) error {
 // It uses a count-based approach which is more robust across GPG versions than
 // trying to match exact key IDs (which can vary in format).
 func (p *Pass) VerifyEncryption(secretName string, expectedGPGIDs []string) error {
-secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
+	secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
-// First, verify all expected GPG IDs exist in the keyring
-for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
-}
-}
+	// First, verify all expected GPG IDs exist in the keyring
+	for _, gpgID := range expectedGPGIDs {
+		cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
+		}
+	}
 
-// Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
-var stdout bytes.Buffer
-cmd.Stdout = &stdout
+	// Count recipients in the encrypted file
+	cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("failed to list packets: %w", err)
-}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to list packets: %w", err)
+	}
 
-// Count how many encryption recipients are in the file
-// Each ":pubkey enc packet:" line represents one recipient
-keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
-matches := keyIDRegex.FindAllString(stdout.String(), -1)
-recipientCount := len(matches)
+	// Count how many encryption recipients are in the file
+	// Each ":pubkey enc packet:" line represents one recipient
+	keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
+	matches := keyIDRegex.FindAllString(stdout.String(), -1)
+	recipientCount := len(matches)
 
-if recipientCount == 0 {
-return fmt.Errorf("no encryption recipients found in %s", secretName)
-}
+	if recipientCount == 0 {
+		return fmt.Errorf("no encryption recipients found in %s", secretName)
+	}
 
-// Verify the count matches
-// Since we know pass was asked to encrypt to exactly these GPG IDs,
-// if the recipient count matches, encryption was successful
-if recipientCount != len(expectedGPGIDs) {
-return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
-secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
-}
+	// Verify the count matches
+	// Since we know pass was asked to encrypt to exactly these GPG IDs,
+	// if the recipient count matches, encryption was successful
+	if recipientCount != len(expectedGPGIDs) {
+		return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
+			secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
+	}
 
-return nil
+	return nil
 }
 
 func (p *Pass) GetGPGIDs() ([]string, error) {

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"


### PR DESCRIPTION
💡 **What**: Added interactive confirmation prompts for all destructive actions (`vault delete`, `delete` secret, and `key remove`). Also added a missing `--force` (`-f`) flag to the `key remove` command for consistency and automation support. Improved the E2E test script to allow environment variable overrides for local testing.

🎯 **Why**: Previously, destructive commands would either fail immediately if `--force` was not provided (for vaults and secrets) or just delete immediately (for keys). This creates an inconsistent experience and increases the risk of accidental data loss. The new interactive confirmation allows users to confirm their intent in a TTY environment while maintaining safe, non-interactive behavior for scripts and CI.

📸 **Before/After**:
*   **Before**: `secrets-cli vault delete dev` -> `Error: use --force to confirm deletion of vault: dev`
*   **After**: `secrets-cli vault delete dev` -> `Are you sure you want to delete vault "dev"? [y/N]: `

♻️ **Accessibility**: Improved command-line accessibility by using quoted string formatting (`%q`) for identifiers in prompts, making it easier for screen readers to distinguish between the message and the entity being acted upon.

---
*PR created automatically by Jules for task [6486539142103172276](https://jules.google.com/task/6486539142103172276) started by @East-rayyy*