### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's UX Journal
+
+## 2025-05-14 - Interactive Confirmation Pattern for Destructive Actions
+**Learning:** Destructive CLI commands should favor interactive confirmation over immediate failure when run in a terminal. This provides a smoother experience than requiring the user to re-run the command with a `--force` flag.
+**Action:** Use the `Confirm(message string, force bool) bool` helper in `internal/cmd/root.go` for all destructive actions. Ensure the helper handles non-interactive environments by failing safely unless forced.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the public key for %q?", email), forceKey) {
+		return fmt.Errorf("action cancelled. Use --force to bypass confirmation")
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,31 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation before performing a destructive action.
+// If force is true, it returns true without prompting.
+// In non-interactive environments, it returns false if not forced.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if stdin is a terminal
+	stat, err := os.Stdin.Stat()
+	if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N] ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,8 +288,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
-		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
+		return fmt.Errorf("action cancelled. Use --force to bypass confirmation")
 	}
 
 	// Delete secret

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,8 +288,8 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
-		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %q and all its secrets?", vaultName), forceDelete) {
+		return fmt.Errorf("action cancelled. Use --force to bypass confirmation")
 	}
 
 	if err := os.RemoveAll(vaultDir); err != nil {


### PR DESCRIPTION
💡 What: Added interactive confirmation prompts for `vault delete`, `delete secret`, and `key remove` commands. Added a `Confirm` helper in `internal/cmd/root.go` and a `--force` flag for `key remove`.

🎯 Why: Previously, destructive commands would immediately fail with an error message instructing the user to use the `--force` flag. This created unnecessary friction for interactive users. Now, the CLI will prompt for confirmation if run in a terminal, while maintaining existing behavior for automated scripts.

📸 Before/After:
Before:
$ secrets-cli vault delete dev
Error: use --force to confirm deletion of vault: dev

After:
$ secrets-cli vault delete dev
Are you sure you want to delete vault "dev" and all its secrets? [y/N] y
✓ Deleted vault: dev

♿ Accessibility: Improved the user experience for keyboard/terminal users by providing clear, interactive feedback for critical actions. Handled non-terminal environments (e.g., CI/CD) by defaulting to safe failure unless forced.

---
*PR created automatically by Jules for task [8085982849732300466](https://jules.google.com/task/8085982849732300466) started by @East-rayyy*