### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in CLI command handlers

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +127,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -273,6 +277,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +322,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +369,21 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -282,6 +286,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -384,6 +392,13 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {

--- a/tests/repro_traversal.sh
+++ b/tests/repro_traversal.sh
@@ -1,25 +1,50 @@
 #!/bin/bash
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
 # Build the binary
 make build
 
-# Use a temporary directory for secrets
-export SECRETS_DIR=".test-secrets-repro"
-rm -rf "$SECRETS_DIR"
+# Initialize a store
+rm -rf .test-secrets
+# We need to be in a git repo for init to work if not absolute path, but current dir is a git repo.
+./secrets-cli init --email test@example.com --secrets-dir .test-secrets
 
-# Initialize
-./secrets-cli init --email sentinel@example.com --secrets-dir "$SECRETS_DIR"
-
-echo "Attempting path traversal in 'key add'..."
-# Attempt path traversal in key add
-# email = ../traversed
-./secrets-cli key add "../traversed" --key-file README.md --secrets-dir "$SECRETS_DIR"
-
-if [ -f "$SECRETS_DIR/traversed.asc" ]; then
-    echo "VULNERABILITY CONFIRMED: Path traversal successful! File created at $SECRETS_DIR/traversed.asc"
-    rm -rf "$SECRETS_DIR"
-    exit 1
+# 1. Test path traversal in 'key add' (Creation)
+echo "Testing path traversal in 'key add'..."
+# Create a dummy key file
+echo "dummy" > dummy.asc
+if ./secrets-cli key add "../../traversal-test" --key-file dummy.asc --secrets-dir .test-secrets 2>&1 | grep -q "invalid name"; then
+    echo -e "${GREEN}✓ Caught path traversal in 'key add'${NC}"
 else
-    echo "Path traversal failed"
-    rm -rf "$SECRETS_DIR"
-    exit 0
+    echo -e "${RED}✗ Failed to catch path traversal in 'key add'${NC}"
+    rm dummy.asc
+    exit 1
 fi
+rm dummy.asc
+
+# 2. Test path traversal in 'list' (Read)
+echo "Testing path traversal in 'list'..."
+if ./secrets-cli list "../../../etc" --secrets-dir .test-secrets 2>&1 | grep -q "invalid name"; then
+    echo -e "${GREEN}✓ Caught path traversal in 'list'${NC}"
+else
+    echo -e "${RED}✗ Failed to catch path traversal in 'list'${NC}"
+    exit 1
+fi
+
+# 3. Test path traversal in 'delete' (Delete)
+echo "Testing path traversal in 'delete'..."
+if ./secrets-cli delete "../../../etc" "passwd" --force --secrets-dir .test-secrets 2>&1 | grep -q "invalid name"; then
+    echo -e "${GREEN}✓ Caught path traversal in 'delete'${NC}"
+else
+    echo -e "${RED}✗ Failed to catch path traversal in 'delete'${NC}"
+    exit 1
+fi
+
+# Clean up
+rm -rf .test-secrets
+echo "All traversal tests passed!"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal in multiple CLI command handlers (list, delete, rename, copy, vault info, vault delete, vault remove-member, key remove).
🎯 Impact: Attackers could potentially read, write, or delete files outside the intended secrets directory by providing manipulated vault or secret names containing path traversal sequences (e.g., `../`).
🔧 Fix: Applied `validateName` and `validateSecretName` to all user-controlled positional arguments in the affected command handlers.
✅ Verification: Created a robust reproduction script `tests/repro_traversal.sh` that attempts path traversal in several commands and verifies they are now correctly rejected. Ran existing unit tests.

---
*PR created automatically by Jules for task [118105800591087991](https://jules.google.com/task/118105800591087991) started by @East-rayyy*