### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-01 - Interactive Confirmation Pattern
+**Learning:** Destructive CLI actions should support both interactive confirmation and a --force flag. Using `os.Stdin.Stat()` to detect `os.ModeCharDevice` allows the tool to provide a helpful prompt in terminals while safely failing in non-interactive environments (CI/CD), preventing hangs.
+**Action:** Use the `Confirm(message string, force bool) bool` pattern for all destructive operations to improve micro-UX without breaking automation.

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfirm(t *testing.T) {
+	// Test with force=true (should always be true)
+	if !Confirm("test", true) {
+		t.Error("Confirm(..., true) should return true")
+	}
+
+	// Test with force=false in non-interactive environment (should be false)
+	// Note: go test usually runs in a non-interactive environment
+	fileInfo, err := os.Stdin.Stat()
+	if err == nil && (fileInfo.Mode()&os.ModeCharDevice) == 0 {
+		if Confirm("test", false) {
+			t.Error("Confirm(..., false) should return false in non-interactive environment")
+		}
+	}
+}

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the public key for %q?", email), forceKey) {
+		return fmt.Errorf("use --force to confirm removal of key: %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,32 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation.
+// It returns true if the user enters 'y' or 'yes' (case-insensitive).
+// If force is true, it returns true without prompting.
+// If not in a terminal and force is false, it returns false.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if stdin is a terminal
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil || (fileInfo.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N]: ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,7 +288,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !Confirm(fmt.Sprintf("Are you sure you want to permanently delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !Confirm(fmt.Sprintf("Are you sure you want to permanently delete vault %q and all its secrets?", vaultName), forceDelete) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 


### PR DESCRIPTION
Implemented interactive confirmation prompts for destructive actions in the secrets-cli.

Key changes:
- Created a `Confirm` utility in `internal/cmd/root.go` that handles interactive input and terminal detection.
- Updated `vault delete` and `delete secret` to use the new confirmation flow.
- Added a `--force` flag and confirmation prompt to `key remove`.
- Added unit tests for the `Confirm` logic in `internal/cmd/confirm_test.go`.
- Updated `.jules/palette.md` with UX learnings.

All 38 E2E tests and unit tests passed.

---
*PR created automatically by Jules for task [12071980038580920920](https://jules.google.com/task/12071980038580920920) started by @East-rayyy*