### PR TITLE
🛡️ Sentinel: HIGH Fix path traversal in multiple CLI command handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** Command handlers for secret operations (`get`, `set`) and vault member management (`add-member`) were missing input validation, potentially allowing path traversal. Additionally, some internal GPG/Pass calls lacked the `--` separator, risking argument injection.
 **Learning:** Even with existing validation functions like `validateName`, it is easy to miss applying them to new command handlers or specific arguments like secret paths that require different rules (e.g., allowing slashes).
 **Prevention:** Apply `validateName` or `validateSecretName` to all user-controlled positional arguments. Ensure all CLI wrappers use the `--` separator before positional arguments to prevent them from being interpreted as flags.
+
+## 2026-03-02 - Comprehensive Path Traversal Protection
+**Vulnerability:** Multiple CLI command handlers (list, delete, rename, copy, info, etc.) were missing input validation on vault names, secret names, and emails, allowing path traversal attacks.
+**Learning:** Security fixes must be applied comprehensively across all entry points that handle user-controlled filenames or paths. Missing a single handler can leave the application vulnerable.
+**Prevention:** Audit all CLI command handlers and ensure 'validateName' or 'validateSecretName' is applied to every user-controlled positional argument. Use a centralized validation utility to maintain consistency.

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,11 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	// Validate name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +128,11 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	// Validate name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,11 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	// Validate name to prevent path traversal and argument injection
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,11 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	// Validate name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -273,6 +278,14 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +324,17 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +372,22 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,11 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	// Validate name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -282,6 +287,11 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+
+	// Validate name to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -384,6 +394,14 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	// Validate names to prevent path traversal and argument injection
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Multiple CLI command handlers were missing input validation on vault names, secret names, and emails, allowing path traversal attacks via manipulated arguments like '../'.
🎯 Impact: Attackers could potentially read or manipulate files outside the intended secrets directory, or perform argument injection against underlying tools like GPG and Pass.
🔧 Fix: Applied the existing `validateName` and `validateSecretName` utility functions to all user-controlled positional arguments in the affected command handlers.
✅ Verification: Ran `tests/repro_traversal.sh` which confirms that path traversal attempts are now rejected with an 'invalid name' error. All existing unit tests pass.

---
*PR created automatically by Jules for task [2812739674759182301](https://jules.google.com/task/2812739674759182301) started by @East-rayyy*