### PR TITLE
🎨 Palette: Add interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-02 - Interactive Confirmation for CLI Safety
+**Learning:** For destructive CLI actions, interactive confirmation prompts [y/N] enhance UX by preventing accidental data loss, but must detect non-terminal environments (e.g., CI/CD) to avoid hanging processes.
+**Action:** Use `os.Stdin.Stat()` to check for `os.ModeCharDevice` before prompting for user input, and always provide a `--force` flag to bypass the prompt for automation.

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestConfirm(t *testing.T) {
+	// Test forced bypass
+	if !Confirm("Are you sure?", true) {
+		t.Error("Expected Confirm to return true when forced, even if not in a terminal")
+	}
+
+	// Test non-terminal environment (which is the case during tests)
+	if Confirm("Are you sure?", false) {
+		t.Error("Expected Confirm to return false in non-terminal environment")
+	}
+}

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove key for %q?", email), forceKey) {
+		return fmt.Errorf("use --force to confirm removal of key for: %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,32 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation with the given message.
+// If force is true, it returns true without prompting.
+// In non-interactive environments, it returns false unless forced.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if stdin is a terminal
+	stat, err := os.Stdin.Stat()
+	if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s [y/N]: ", message)
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "y" || input == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,7 +288,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %q?", vaultName), forceDelete) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -206,44 +206,44 @@ func (p *Pass) ReInit(gpgIDs []string) error {
 // It uses a count-based approach which is more robust across GPG versions than
 // trying to match exact key IDs (which can vary in format).
 func (p *Pass) VerifyEncryption(secretName string, expectedGPGIDs []string) error {
-secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
+	secretPath := filepath.Join(p.StoreDir, secretName+".gpg")
 
-// First, verify all expected GPG IDs exist in the keyring
-for _, gpgID := range expectedGPGIDs {
-cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
-}
-}
+	// First, verify all expected GPG IDs exist in the keyring
+	for _, gpgID := range expectedGPGIDs {
+		cmd := exec.Command("gpg", "--list-keys", "--", gpgID)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("GPG ID %s not found in keyring: %w", gpgID, err)
+		}
+	}
 
-// Count recipients in the encrypted file
-cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
-var stdout bytes.Buffer
-cmd.Stdout = &stdout
+	// Count recipients in the encrypted file
+	cmd := exec.Command("gpg", "--list-packets", "--", secretPath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
-if err := cmd.Run(); err != nil {
-return fmt.Errorf("failed to list packets: %w", err)
-}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to list packets: %w", err)
+	}
 
-// Count how many encryption recipients are in the file
-// Each ":pubkey enc packet:" line represents one recipient
-keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
-matches := keyIDRegex.FindAllString(stdout.String(), -1)
-recipientCount := len(matches)
+	// Count how many encryption recipients are in the file
+	// Each ":pubkey enc packet:" line represents one recipient
+	keyIDRegex := regexp.MustCompile(`(?i):pubkey enc packet:`)
+	matches := keyIDRegex.FindAllString(stdout.String(), -1)
+	recipientCount := len(matches)
 
-if recipientCount == 0 {
-return fmt.Errorf("no encryption recipients found in %s", secretName)
-}
+	if recipientCount == 0 {
+		return fmt.Errorf("no encryption recipients found in %s", secretName)
+	}
 
-// Verify the count matches
-// Since we know pass was asked to encrypt to exactly these GPG IDs,
-// if the recipient count matches, encryption was successful
-if recipientCount != len(expectedGPGIDs) {
-return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
-secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
-}
+	// Verify the count matches
+	// Since we know pass was asked to encrypt to exactly these GPG IDs,
+	// if the recipient count matches, encryption was successful
+	if recipientCount != len(expectedGPGIDs) {
+		return fmt.Errorf("secret %s is encrypted for %d recipients, but expected %d (GPG IDs: %v)",
+			secretName, recipientCount, len(expectedGPGIDs), expectedGPGIDs)
+	}
 
-return nil
+	return nil
 }
 
 func (p *Pass) GetGPGIDs() ([]string, error) {


### PR DESCRIPTION
💡 What: Added interactive [y/N] confirmation prompts for destructive CLI commands (`vault delete`, `secret delete`, and `key remove`).

🎯 Why: Prevents accidental data loss by requiring explicit confirmation from the user in interactive terminals. It replaces hard errors with a friendly prompt.

📸 Before/After:
Before: `secrets-cli vault delete dev` -> Fails with "use --force to confirm..."
After: `secrets-cli vault delete dev` -> Prompts "Are you sure you want to delete vault "dev"? [y/N]:"

♻️ Accessibility: Improves usability by providing a safety net for destructive actions while remaining script-friendly by auto-failing or accepting `--force` in non-interactive environments. Used quoted formatting for entity names in prompts for better clarity.

---
*PR created automatically by Jules for task [10275695077408164529](https://jules.google.com/task/10275695077408164529) started by @East-rayyy*