### PR TITLE
🎨 Palette: add interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-03 - Interactive Confirmation UX Pattern
+**Learning:** Destructive CLI commands (vault/secret/key deletion) should provide an interactive [y/N] prompt when run in a terminal to prevent accidental data loss, while still supporting a `--force` flag for non-interactive/automation environments. This balanced approach improves usability without breaking CI/CD pipelines. Using quoted formatting (`%q`) for entity names in prompts makes them clearer.
+**Action:** Always implement the `Confirm` pattern for destructive operations and ensure terminal detection using `os.Stdin.Stat()` and `os.ModeCharDevice`.

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfirm(t *testing.T) {
+	// Test force flag
+	if !Confirm("test", true) {
+		t.Errorf("Confirm with force=true should return true")
+	}
+
+	// Test non-terminal environment
+	// In most CI environments, os.Stdin is not a terminal.
+	// Even if it were, we want to ensure it handles non-terminal gracefully.
+
+	// Create a pipe to simulate non-terminal stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	if Confirm("test", false) {
+		t.Errorf("Confirm without force in non-terminal should return false")
+	}
+}

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force removal without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the key for %q?", email), forceKey) {
+		return fmt.Errorf("use --force to confirm removal of key for: %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,31 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation.
+// If force is true, it returns true immediately.
+// If not in a terminal, it returns false unless force is true.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if stdin is a terminal
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil || (fileInfo.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N] ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,7 +288,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %q and all its secrets?", vaultName), forceDelete) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 


### PR DESCRIPTION
🎨 Palette: [UX improvement] add interactive confirmation for destructive actions

💡 What:
Added interactive [y/N] confirmation prompts for destructive CLI actions:
- `secrets-cli vault delete <vault>`
- `secrets-cli delete <vault> <secret>`
- `secrets-cli key remove <email>`

Added a new `-f/--force` flag to the `key remove` command.

🎯 Why:
Prevents accidental deletion of vaults, secrets, or keys by providing a safety check. The implementation detects if it's running in a terminal, ensuring it doesn't hang in non-interactive environments (CI) if the `--force` flag is omitted.

📸 Before/After:
Before:
`$ secrets-cli vault delete myvault`
`Error: use --force to confirm deletion of vault: myvault`

After (interactive):
`$ secrets-cli vault delete myvault`
`Are you sure you want to delete vault "myvault" and all its secrets? [y/N] y`
`✓ Deleted vault: myvault`

♿ Accessibility:
- Clear, descriptive prompts using quoted names for clarity.
- Interactive prompts only appear in terminal environments.
- Consistent confirmation pattern across all destructive commands.

♻️ Reusability:
- Centralized `Confirm` helper function in `internal/cmd/root.go` can be reused for any future confirmation needs.

---
*PR created automatically by Jules for task [3575666215493755572](https://jules.google.com/task/3575666215493755572) started by @East-rayyy*