### PR TITLE
🎨 Palette: Add interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-05 - [Interactive Confirmation Prompts]
+**Learning:** For destructive CLI actions, requiring a `--force` flag is a good baseline, but providing an interactive confirmation prompt when the flag is missing and a terminal is present significantly improves the user experience by offering a safety net without breaking automation. Checking for a terminal environment using `os.Stdin.Stat()` is crucial to prevent the CLI from hanging in non-interactive environments like CI/CD.
+**Action:** Use a centralized `Confirm` helper that respects both `--force` flags and terminal presence for all destructive operations.

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -13,8 +13,8 @@ func TestConfirm(t *testing.T) {
 
 	// Test non-interactive environment
 	// In the test environment, os.Stdin might not be a terminal
-	fileInfo, _ := os.Stdin.Stat()
-	isTerminal := (fileInfo.Mode() & os.ModeCharDevice) != 0
+	fileInfo, err := os.Stdin.Stat()
+	isTerminal := err == nil && (fileInfo.Mode()&os.ModeCharDevice) != 0
 
 	if !isTerminal {
 		if Confirm("test", false) {

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfirm(t *testing.T) {
+	// Test forced confirmation
+	if !Confirm("test", true) {
+		t.Errorf("Confirm should return true when forced")
+	}
+
+	// Test non-interactive environment
+	// In the test environment, os.Stdin might not be a terminal
+	fileInfo, _ := os.Stdin.Stat()
+	isTerminal := (fileInfo.Mode() & os.ModeCharDevice) != 0
+
+	if !isTerminal {
+		if Confirm("test", false) {
+			t.Errorf("Confirm should return false in non-interactive environment")
+		}
+	}
+}

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the public key for %q?", email), forceKey) {
+		return fmt.Errorf("use --force to confirm removal of key for: %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,29 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation [y/N]
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if stdin is a terminal
+	fileInfo, _ := os.Stdin.Stat()
+	if (fileInfo.Mode() & os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N]: ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -193,8 +193,8 @@ func Confirm(message string, force bool) bool {
 	}
 
 	// Check if stdin is a terminal
-	fileInfo, _ := os.Stdin.Stat()
-	if (fileInfo.Mode() & os.ModeCharDevice) == 0 {
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil || (fileInfo.Mode()&os.ModeCharDevice) == 0 {
 		return false
 	}
 

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,7 +288,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %q and all its secrets?", vaultName), forceDelete) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="/workspace"
-SECRET_CLI="${WORKSPACE}/secrets-cli"
+WORKSPACE="${WORKSPACE:-/tmp/test-workspace}"
+SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"

--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="${WORKSPACE:-/tmp/test-workspace}"
-SECRET_CLI="${SECRET_CLI:-${WORKSPACE}/secrets-cli}"
+WORKSPACE="/workspace"
+SECRET_CLI="${WORKSPACE}/secrets-cli"
 
 # Source test utilities
 source "${SCRIPT_DIR}/test-utils.sh"
@@ -490,6 +490,31 @@ test_key_add_bob() {
     return 0
 }
 
+test_key_remove() {
+    cd "$TEST_DIR"
+
+    # Create a key to remove
+    local charlie_email="charlie@test.local"
+    generate_gpg_key "$charlie_email" "Charlie Test"
+    assert_success "$SECRET_CLI key add $charlie_email" || return 1
+    assert_file_exists ".secrets/keys/${charlie_email}.asc" || return 1
+
+    # Attempt remove without force (should fail in non-interactive environment)
+    assert_failure "$SECRET_CLI key remove $charlie_email" || return 1
+    assert_output_contains "use --force" || return 1
+
+    # Remove with force
+    assert_success "$SECRET_CLI key remove $charlie_email --force" || return 1
+
+    # Verify it's gone
+    if [[ -f ".secrets/keys/${charlie_email}.asc" ]]; then
+        test_fail "key removed" "key file still exists"
+        return 1
+    fi
+
+    return 0
+}
+
 test_key_list_shows_both() {
     cd "$TEST_DIR"
     
@@ -834,6 +859,8 @@ register_tests() {
         "List stored public GPG keys"
     register_test "key_add_bob" test_key_add_bob \
         "Add Bob's public key to .secrets/keys/"
+    register_test "key_remove" test_key_remove \
+        "Remove a GPG key with --force flag"
     register_test "key_list_shows_both" test_key_list_shows_both \
         "Verify both Alice and Bob keys listed"
     

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -59,7 +59,7 @@ build_image() {
         image_created=$(docker image inspect "$IMAGE_NAME" --format '{{.Created}}' 2>/dev/null || echo "1970-01-01")
         
         local needs_rebuild=false
-        for file in "${PROJECT_DIR}/secret-cli" "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}/test-utils.sh" "${SCRIPT_DIR}/e2e-tests.sh"; do
+        for file in "${PROJECT_DIR}/secrets-cli" "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}/test-utils.sh" "${SCRIPT_DIR}/e2e-tests.sh"; do
             if [[ -f "$file" ]] && [[ "$file" -nt "${SCRIPT_DIR}/.image-timestamp" ]]; then
                 needs_rebuild=true
                 break


### PR DESCRIPTION
💡 What: Added an interactive [y/N] confirmation prompt for destructive actions (`vault delete`, `delete secret`, and `key remove`).

🎯 Why: To prevent accidental data loss for interactive users while maintaining compatibility for automated workflows via the `--force` flag. Previously, these commands either failed immediately without `--force` or lacked a safety check entirely.

♿ Accessibility: Improved safety for keyboard-driven interactive use. The tool now detects if it's running in a terminal; if not (e.g., CI/CD), it defaults to requiring the `--force` flag to avoid hanging.

📸 Before/After:
Before: `secrets-cli vault delete dev` -> `Error: use --force to confirm deletion...`
After: `secrets-cli vault delete dev` -> `Are you sure you want to delete vault "dev" and all its secrets? [y/N]: `

---
*PR created automatically by Jules for task [5841315925802547081](https://jules.google.com/task/5841315925802547081) started by @East-rayyy*