### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in multiple CLI commands

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +127,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -47,6 +47,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check if already initialized
 	if _, err := os.Stat(secretsDir); !os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory already exists: %s. Remove it first or use a different path", secretsDir)

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -273,6 +277,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +322,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +369,21 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -34,6 +34,10 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	// Check if secrets directory exists
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -282,6 +286,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -384,6 +392,13 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Multiple CLI command handlers were using user-provided arguments (vault names, secret names, emails) to construct file paths without validation, allowing for path traversal attacks.
🎯 **Impact**: An attacker could potentially read, write, or delete arbitrary files on the system by providing malicious inputs like `../../path/to/file`.
🔧 **Fix**: Integrated `validateName` and `validateSecretName` checks into the following handlers:
- `runKeyRemove` (internal/cmd/key.go)
- `runList`, `runDelete`, `runRename`, `runCopy` (internal/cmd/secrets.go)
- `runVaultInfo`, `runVaultDelete`, `runVaultRemoveMember` (internal/cmd/vault.go)
- `runExport`, `runSync` (internal/cmd/export.go)
- `runSetup` (internal/cmd/setup.go)
- `runInit` (internal/cmd/init.go)
✅ **Verification**:
- Verified the fix for `key remove` using a reproduction script that attempted to delete a file outside the keys directory.
- Ran `go test ./...` to ensure no regressions in validation logic.
- Confirmed code builds successfully with `go build ./...`.
- Cleaned up all temporary test artifacts.

---
*PR created automatically by Jules for task [10969910600857920449](https://jules.google.com/task/10969910600857920449) started by @East-rayyy*