### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in key and vault commands

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -53,6 +53,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -123,6 +127,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -47,6 +47,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if email != "" {
+		if err := validateName(email); err != nil {
+			return err
+		}
+	}
+
 	// Check if already initialized
 	if _, err := os.Stat(secretsDir); !os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory already exists: %s. Remove it first or use a different path", secretsDir)

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -160,6 +160,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := args[0]
 
+	if err := validateName(email); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -117,6 +117,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -273,6 +277,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	vaultName := args[0]
 	secretName := args[1]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -311,6 +322,16 @@ func runRename(cmd *cobra.Command, args []string) error {
 	oldName := args[1]
 	newName := args[2]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateSecretName(oldName); err != nil {
+		return err
+	}
+	if err := validateSecretName(newName); err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)
 	}
@@ -348,6 +369,21 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	srcVault := args[0]
 	secretName := args[1]
 	dstVault := args[2]
+
+	if err := validateName(srcVault); err != nil {
+		return err
+	}
+	if err := validateSecretName(secretName); err != nil {
+		return err
+	}
+	if err := validateName(dstVault); err != nil {
+		return err
+	}
+	if newSecretName != "" {
+		if err := validateSecretName(newSecretName); err != nil {
+			return err
+		}
+	}
 
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("✗ Secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -34,6 +34,12 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	email := GetUserEmail()
 
+	if email != "" {
+		if err := validateName(email); err != nil {
+			return err
+		}
+	}
+
 	// Check if secrets directory exists
 	if _, err := os.Stat(secretsDir); os.IsNotExist(err) {
 		return fmt.Errorf("secrets directory not found: %s. Run 'secrets-cli init' first", secretsDir)

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -246,6 +246,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
 
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
 		return fmt.Errorf("vault not found: %s", vaultName)
@@ -282,6 +286,10 @@ func runVaultInfo(cmd *cobra.Command, args []string) error {
 func runVaultDelete(cmd *cobra.Command, args []string) error {
 	secretsDir := GetSecretsDir()
 	vaultName := args[0]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {
@@ -384,6 +392,13 @@ func runVaultRemoveMember(cmd *cobra.Command, args []string) error {
 	email := GetUserEmail()
 	vaultName := args[0]
 	memberEmail := args[1]
+
+	if err := validateName(vaultName); err != nil {
+		return err
+	}
+	if err := validateName(memberEmail); err != nil {
+		return err
+	}
 
 	vaultDir := config.GetVaultDir(secretsDir, vaultName)
 	if _, err := os.Stat(vaultDir); os.IsNotExist(err) {

--- a/tests/repro_key_traversal.sh
+++ b/tests/repro_key_traversal.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SECRET_CLI_BIN=$(pwd)/secrets-cli
+WORKSPACE=$(mktemp -d)
+cd "$WORKSPACE"
+echo "sensitive data" > sensitive.asc
+mkdir -p .secrets/keys
+echo "Testing for path traversal vulnerability in 'key remove'..."
+$SECRET_CLI_BIN key remove "../../sensitive"
+if [ ! -f sensitive.asc ]; then
+    echo "VULNERABILITY CONFIRMED: sensitive.asc was deleted!"
+    rm -rf "$WORKSPACE"
+    # End script with non-zero
+    (exit 1)
+else
+    echo "SUCCESS: sensitive.asc was NOT deleted."
+    rm -rf "$WORKSPACE"
+    # End script with zero
+    (exit 0)
+fi


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix path traversal in key and vault commands

### 🚨 Severity: CRITICAL

### 💡 Vulnerability
Path traversal in multiple CLI command handlers (`key`, `vault`, `secrets`, `export`) allowed arbitrary file access or deletion via manipulated email, vault, or secret names. Specifically, the `key remove` command could be used to delete any file with a `.asc` extension by providing a malicious email argument like `../../sensitive`.

### 🎯 Impact
An attacker could delete sensitive files on the user's system (if they have `.asc` extension) or manipulate the `.secrets` directory structure to bypass access controls or cause data loss.

### 🔧 Fix
Applied `validateName` and `validateSecretName` (defined in `internal/cmd/root.go`) to all user-controlled positional arguments and flags across all command handlers:
- `internal/cmd/key.go`: `runKeyRemove`
- `internal/cmd/secrets.go`: `runList`, `runDelete`, `runRename`, `runCopy`
- `internal/cmd/vault.go`: `runVaultInfo`, `runVaultDelete`, `runVaultRemoveMember`
- `internal/cmd/export.go`: `runExport`, `runSync`
- `internal/cmd/init.go`: `runInit`
- `internal/cmd/setup.go`: `runSetup`

### ✅ Verification
- Created a reproduction script `tests/repro_key_traversal.sh` which successfully exploited the vulnerability before the fix.
- Verified that the reproduction script is blocked and returns an error after applying the fixes.
- Ran the full project test suite (`make test`) and all tests passed.


---
*PR created automatically by Jules for task [17045056573597412506](https://jules.google.com/task/17045056573597412506) started by @East-rayyy*