### PR TITLE
🎨 Palette: Interactive confirmation for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-09 - Interactive Confirmation Pattern for CLI
+**Learning:** Destructive CLI actions should have a safety net. While a --force flag is standard for automation, interactive users benefit greatly from a confirmation prompt. Detecting the terminal environment via os.Stdin.Stat() allows for a seamless transition between interactive use and automated scripts.
+**Action:** Use the shared Confirm helper in internal/cmd/root.go for all destructive operations (delete, remove, etc.) to ensure a consistent and safe user experience.

--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -69,7 +69,10 @@ called automatically by 'secrets-cli setup'.`,
 	RunE: runKeyImport,
 }
 
-var keyFile string
+var (
+	keyFile  string
+	forceKey bool
+)
 
 func init() {
 	rootCmd.AddCommand(keyCmd)
@@ -79,6 +82,7 @@ func init() {
 	keyCmd.AddCommand(keyImportCmd)
 
 	keyAddCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to key file (optional)")
+	keyRemoveCmd.Flags().BoolVarP(&forceKey, "force", "f", false, "Force remove key without confirmation")
 }
 
 func runKeyList(cmd *cobra.Command, args []string) error {
@@ -169,6 +173,10 @@ func runKeyRemove(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("no key found for %s", email)
+	}
+
+	if !Confirm(fmt.Sprintf("Are you sure you want to remove the GPG key for %q?", email), forceKey) {
+		return fmt.Errorf("use --force to confirm removal of key for: %s", email)
 	}
 
 	if err := os.Remove(keyPath); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -183,6 +184,31 @@ func validateName(name string) error {
 		return fmt.Errorf("invalid name: %s (contains illegal characters or path traversal)", name)
 	}
 	return nil
+}
+
+// Confirm prompts the user for confirmation with a message.
+// If force is true, it returns true immediately.
+// If not in a terminal and force is false, it returns false.
+func Confirm(message string, force bool) bool {
+	if force {
+		return true
+	}
+
+	// Check if we have a terminal
+	fi, err := os.Stdin.Stat()
+	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return false
+	}
+
+	fmt.Printf("%s [y/N] ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // validateSecretName ensures a secret name is safe to use.

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -288,7 +288,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Access denied: you are not a member of vault %s", vaultName)
 	}
 
-	if !forceSecret {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete secret %q from vault %q?", secretName, vaultName), forceSecret) {
 		return fmt.Errorf("use --force to confirm deletion of secret: %s/%s", vaultName, secretName)
 	}
 

--- a/internal/cmd/vault.go
+++ b/internal/cmd/vault.go
@@ -288,7 +288,7 @@ func runVaultDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vault not found: %s", vaultName)
 	}
 
-	if !forceDelete {
+	if !Confirm(fmt.Sprintf("Are you sure you want to delete vault %q and all its secrets?", vaultName), forceDelete) {
 		return fmt.Errorf("use --force to confirm deletion of vault: %s", vaultName)
 	}
 


### PR DESCRIPTION
### 🎨 Palette: Interactive confirmation for destructive actions

#### 💡 What
Added a standardized interactive confirmation prompt for vault, secret, and key deletion operations.

#### 🎯 Why
Prevents accidental data loss by providing a safety net for interactive users. It makes the CLI feel more professional and "safe" to use, while maintaining full compatibility for automation scripts via the existing (and newly added for keys) `--force` flag.

#### 📸 Before/After
- **Before:** Destructive commands would error out immediately if `--force` was not provided, even in an interactive terminal.
- **After:** 
  - **Interactive:** Prompts the user: `Are you sure you want to delete ...? [y/N]`.
  - **Non-interactive (CI):** Fails gracefully with a helpful message: `use --force to confirm deletion of ...`.

#### ♿ Accessibility
Improves usability for keyboard/terminal users by providing immediate feedback and a clear confirmation step for irreversible actions. Identifiers are now quoted in prompts for better visual distinction.

---
*PR created automatically by Jules for task [10507842697443924961](https://jules.google.com/task/10507842697443924961) started by @East-rayyy*